### PR TITLE
Add support for SPI.

### DIFF
--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,8 +1,8 @@
-extern crate linux_embedded_hal as hal;
 extern crate bme280;
+extern crate linux_embedded_hal as hal;
 
+use bme280::i2c::BME280;
 use hal::{Delay, I2cdev};
-use bme280::BME280;
 use std::thread;
 use std::time::Duration;
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,0 +1,115 @@
+//! BME280 driver for sensors attached via I2C.
+
+use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
+
+use super::{
+    BME280Common, Error, Interface, Measurements, BME280_H_CALIB_DATA_LEN,
+    BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN,
+};
+
+const BME280_I2C_ADDR_PRIMARY: u8 = 0x76;
+const BME280_I2C_ADDR_SECONDARY: u8 = 0x77;
+
+/// Representation of a BME280
+#[derive(Debug, Default)]
+pub struct BME280<I2C, D> {
+    common: BME280Common<I2CInterface<I2C>, D>,
+}
+
+impl<I2C, D, E> BME280<I2C, D>
+where
+    I2C: Read<Error = E> + Write<Error = E> + WriteRead<Error = E>,
+    D: DelayMs<u8>,
+{
+    /// Create a new BME280 struct using the primary I²C address `0x76`
+    pub fn new_primary(i2c: I2C, delay: D) -> Self {
+        Self::new(i2c, BME280_I2C_ADDR_PRIMARY, delay)
+    }
+
+    /// Create a new BME280 struct using the secondary I²C address `0x77`
+    pub fn new_secondary(i2c: I2C, delay: D) -> Self {
+        Self::new(i2c, BME280_I2C_ADDR_SECONDARY, delay)
+    }
+
+    /// Create a new BME280 struct using a custom I²C address
+    pub fn new(i2c: I2C, address: u8, delay: D) -> Self {
+        BME280 {
+            common: BME280Common {
+                interface: I2CInterface { i2c, address },
+                delay,
+                calibration: None,
+            },
+        }
+    }
+
+    /// Initializes the BME280
+    pub fn init(&mut self) -> Result<(), Error<E>> {
+        self.common.init()
+    }
+
+    /// Captures and processes sensor data for temperature, pressure, and humidity
+    pub fn measure(&mut self) -> Result<Measurements<E>, Error<E>> {
+        self.common.measure()
+    }
+}
+
+/// Register access functions for I2C
+#[derive(Debug, Default)]
+struct I2CInterface<I2C> {
+    /// concrete I²C device implementation
+    i2c: I2C,
+    /// I²C device address
+    address: u8,
+}
+
+impl<I2C, E> Interface for I2CInterface<I2C>
+where
+    I2C: Read<Error = E> + Write<Error = E> + WriteRead<Error = E>,
+{
+    type Error = E;
+
+    fn read_register(&mut self, register: u8) -> Result<u8, Error<E>> {
+        let mut data: [u8; 1] = [0];
+        self.i2c
+            .write_read(self.address, &[register], &mut data)
+            .map_err(Error::Bus)?;
+        Ok(data[0])
+    }
+
+    fn read_data(&mut self, register: u8) -> Result<[u8; BME280_P_T_H_DATA_LEN], Error<E>> {
+        let mut data: [u8; BME280_P_T_H_DATA_LEN] = [0; BME280_P_T_H_DATA_LEN];
+        self.i2c
+            .write_read(self.address, &[register], &mut data)
+            .map_err(Error::Bus)?;
+        Ok(data)
+    }
+
+    fn read_pt_calib_data(
+        &mut self,
+        register: u8,
+    ) -> Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<E>> {
+        let mut data: [u8; BME280_P_T_CALIB_DATA_LEN] = [0; BME280_P_T_CALIB_DATA_LEN];
+        self.i2c
+            .write_read(self.address, &[register], &mut data)
+            .map_err(Error::Bus)?;
+        Ok(data)
+    }
+
+    fn read_h_calib_data(
+        &mut self,
+        register: u8,
+    ) -> Result<[u8; BME280_H_CALIB_DATA_LEN], Error<E>> {
+        let mut data: [u8; BME280_H_CALIB_DATA_LEN] = [0; BME280_H_CALIB_DATA_LEN];
+        self.i2c
+            .write_read(self.address, &[register], &mut data)
+            .map_err(Error::Bus)?;
+        Ok(data)
+    }
+
+    fn write_register(&mut self, register: u8, payload: u8) -> Result<(), Error<E>> {
+        self.i2c
+            .write(self.address, &[register, payload])
+            .map_err(Error::Bus)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,8 +141,8 @@ macro_rules! set_bits {
 pub enum Error<E> {
     /// Failed to compensate a raw measurement
     CompensationFailed,
-    /// I²C bus error
-    I2c(E),
+    /// I²C or SPI bus error
+    Bus(E),
     /// Failed to parse sensor data
     InvalidData,
     /// No calibration data is available (probably forgot to call or check BME280::init for failure)
@@ -418,7 +418,7 @@ where
         let mut data: [u8; 1] = [0];
         self.i2c
             .write_read(self.address, &[BME280_PWR_CTRL_ADDR], &mut data)
-            .map_err(Error::I2c)?;
+            .map_err(Error::Bus)?;
         match data[0] & BME280_SENSOR_MODE_MSK {
             BME280_SLEEP_MODE => Ok(SensorMode::Sleep),
             BME280_FORCED_MODE => Ok(SensorMode::Forced),
@@ -459,7 +459,7 @@ where
         let mut data: [u8; 1] = [0];
         self.i2c
             .write_read(self.address, &[register], &mut data)
-            .map_err(Error::I2c)?;
+            .map_err(Error::Bus)?;
         Ok(data[0])
     }
 
@@ -467,7 +467,7 @@ where
         let mut data: [u8; BME280_P_T_H_DATA_LEN] = [0; BME280_P_T_H_DATA_LEN];
         self.i2c
             .write_read(self.address, &[register], &mut data)
-            .map_err(Error::I2c)?;
+            .map_err(Error::Bus)?;
         Ok(data)
     }
 
@@ -478,7 +478,7 @@ where
         let mut data: [u8; BME280_P_T_CALIB_DATA_LEN] = [0; BME280_P_T_CALIB_DATA_LEN];
         self.i2c
             .write_read(self.address, &[register], &mut data)
-            .map_err(Error::I2c)?;
+            .map_err(Error::Bus)?;
         Ok(data)
     }
 
@@ -489,14 +489,14 @@ where
         let mut data: [u8; BME280_H_CALIB_DATA_LEN] = [0; BME280_H_CALIB_DATA_LEN];
         self.i2c
             .write_read(self.address, &[register], &mut data)
-            .map_err(Error::I2c)?;
+            .map_err(Error::Bus)?;
         Ok(data)
     }
 
     fn write_register(&mut self, register: u8, payload: u8) -> Result<(), Error<E>> {
         self.i2c
             .write(self.address, &[register, payload])
-            .map_err(Error::I2c)
+            .map_err(Error::Bus)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! The [Bosch BMP280](https://www.bosch-sensortec.com/bst/products/all_products/bmp280)
 //! is a highly accurate sensor for atmospheric temperature, and pressure.
 //!
-//! The device has I²C and SPI interfaces (SPI is not currently supported).
+//! The device has I²C and SPI interfaces.
 //!
 //! ## Usage
 //!
@@ -63,6 +63,7 @@
 //! ```
 
 pub mod i2c;
+pub mod spi;
 
 use core::marker::PhantomData;
 use embedded_hal::blocking::delay::DelayMs;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,0 +1,150 @@
+//! BME280 driver for sensors attached via SPI.
+
+use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::blocking::spi::Transfer;
+use embedded_hal::digital::v2::OutputPin;
+
+use super::{
+    BME280Common, Error, Interface, Measurements, BME280_H_CALIB_DATA_LEN,
+    BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN,
+};
+
+/// Representation of a BME280
+#[derive(Debug, Default)]
+pub struct BME280<SPI, CS, D> {
+    common: BME280Common<SPIInterface<SPI, CS>, D>,
+}
+
+impl<SPI, CS, D, SPIE, PinE> BME280<SPI, CS, D>
+where
+    SPI: Transfer<u8, Error = SPIE>,
+    CS: OutputPin<Error = PinE>,
+    D: DelayMs<u8>,
+{
+    /// Create a new BME280 struct
+    pub fn new(spi: SPI, mut cs: CS, delay: D) -> Result<Self, Error<SPIError<SPIE, PinE>>> {
+        // Deassert chip-select.
+        cs.set_high().map_err(|e| Error::Bus(SPIError::Pin(e)))?;
+
+        Ok(BME280 {
+            common: BME280Common {
+                interface: SPIInterface { spi, cs },
+                delay,
+                calibration: None,
+            },
+        })
+    }
+
+    /// Initializes the BME280
+    pub fn init(&mut self) -> Result<(), Error<SPIError<SPIE, PinE>>> {
+        self.common.init()
+    }
+
+    /// Captures and processes sensor data for temperature, pressure, and humidity
+    pub fn measure(
+        &mut self,
+    ) -> Result<Measurements<SPIError<SPIE, PinE>>, Error<SPIError<SPIE, PinE>>> {
+        self.common.measure()
+    }
+}
+
+/// Register access functions for SPI
+#[derive(Debug, Default)]
+struct SPIInterface<SPI, CS> {
+    /// concrete SPI device implementation
+    spi: SPI,
+    /// chip-select pin
+    cs: CS,
+}
+
+impl<SPI, CS> Interface for SPIInterface<SPI, CS>
+where
+    SPI: Transfer<u8>,
+    CS: OutputPin,
+{
+    type Error = SPIError<SPI::Error, CS::Error>;
+
+    fn read_register(&mut self, register: u8) -> Result<u8, Error<Self::Error>> {
+        let mut result = [0u8];
+        self.read_any_register(register, &mut result)?;
+        Ok(result[0])
+    }
+
+    fn read_data(
+        &mut self,
+        register: u8,
+    ) -> Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>> {
+        let mut data: [u8; BME280_P_T_H_DATA_LEN] = [0; BME280_P_T_H_DATA_LEN];
+        self.read_any_register(register, &mut data)?;
+        Ok(data)
+    }
+
+    fn read_pt_calib_data(
+        &mut self,
+        register: u8,
+    ) -> Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>> {
+        let mut data: [u8; BME280_P_T_CALIB_DATA_LEN] = [0; BME280_P_T_CALIB_DATA_LEN];
+        self.read_any_register(register, &mut data)?;
+        Ok(data)
+    }
+
+    fn read_h_calib_data(
+        &mut self,
+        register: u8,
+    ) -> Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>> {
+        let mut data: [u8; BME280_H_CALIB_DATA_LEN] = [0; BME280_H_CALIB_DATA_LEN];
+        self.read_any_register(register, &mut data)?;
+        Ok(data)
+    }
+
+    fn write_register(&mut self, register: u8, payload: u8) -> Result<(), Error<Self::Error>> {
+        self.cs
+            .set_low()
+            .map_err(|e| Error::Bus(SPIError::Pin(e)))?;
+        // If the first bit is 0, the register is written.
+        let mut transfer = [register & 0x7f, payload];
+        self.spi
+            .transfer(&mut transfer)
+            .map_err(|e| Error::Bus(SPIError::SPI(e)))?;
+        self.cs
+            .set_high()
+            .map_err(|e| Error::Bus(SPIError::Pin(e)))?;
+        Ok(())
+    }
+}
+
+impl<SPI, CS> SPIInterface<SPI, CS>
+where
+    SPI: Transfer<u8>,
+    CS: OutputPin,
+{
+    fn read_any_register(
+        &mut self,
+        register: u8,
+        data: &mut [u8],
+    ) -> Result<(), Error<SPIError<SPI::Error, CS::Error>>> {
+        self.cs
+            .set_low()
+            .map_err(|e| Error::Bus(SPIError::Pin(e)))?;
+        let mut register = [register];
+        self.spi
+            .transfer(&mut register)
+            .map_err(|e| Error::Bus(SPIError::SPI(e)))?;
+        self.spi
+            .transfer(data)
+            .map_err(|e| Error::Bus(SPIError::SPI(e)))?;
+        self.cs
+            .set_high()
+            .map_err(|e| Error::Bus(SPIError::Pin(e)))?;
+        Ok(())
+    }
+}
+
+/// Error which occurred during an SPI transaction
+#[derive(Clone, Copy, Debug)]
+pub enum SPIError<SPIE, PinE> {
+    /// The SPI implementation returned an error
+    SPI(SPIE),
+    /// The GPIO implementation returned an error which changing the chip-select pin state
+    Pin(PinE),
+}


### PR DESCRIPTION
The patches add support for BME280s connected via SPI. They move the i2c-specific parts of the driver to crate::i2c:: and add a second "BME280" struct in crate::spi::.

What is still missing is an example about how to use the sensor - where should that example go?

I was not able to test I2C functionality after the changes, but SPI seems to work.