### PR TITLE
Configure before calibrate (fix for uber-foo/bme280-rs#5)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,8 +350,8 @@ where
     pub fn init(&mut self) -> Result<(), Error<E>> {
         self.verify_chip_id()?;
         self.soft_reset()?;
-        self.calibrate()?;
-        self.configure()
+        self.configure()?;
+        self.calibrate()
     }
 
     fn verify_chip_id(&mut self) -> Result<(), Error<E>> {


### PR DESCRIPTION
I hit the same issue as described in uber-foo/bme280-rs#5.

I looked at the calibration data and found that it was incorrect (if I remember correctly, `dig_t1`, `dig_t2` and `dig_t3` were all `0`). I tried making `calibrate()` public and call it again if receiving `Error::InvalidData`. Except for the first call that was always failing, the next calls work.

I tried inverting the `calibrate()` and `configure()` calls and it worked as well, which seems to be the best solution. @Glaeqen, can you confirm if this fixes the issue for you?