### PR TITLE
Allow idiomatic error handling by optionally including std::error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,13 @@ keywords = ["bme280", "bmp280", "temperature", "pressure", "humidity"]
 categories = ["embedded", "no-std", "hardware-support"]
 edition = "2018"
 
+[features]
+with-std = ["derive_more"]
+
 [dependencies]
 embedded-hal = "0.2.3"
 serde = { version = "1.0.104", optional = true, features = ["derive"] }
+derive_more = { version = "0.99.11", optional = true}
 
 [dev-dependencies]
 linux-embedded-hal = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bme280"
-version = "0.2.1"
+version = "0.3.1"
 authors = ["Sean Bruton <sean@uberfoo.net>"]
 description = "A rust device driver for the Bosch BME280 temperature, humidity, and atmospheric pressure sensor and the Bosch BMP280 temperature, and atmospheric pressure sensor"
 repository = "https://github.com/uber-foo/bme280-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@
     unused_imports,
     unused_must_use
 )]
-#![no_std]
+// Turn off std if we turn on the "with-std" feature
+#![cfg_attr(not(feature = "with-std"), no_std)]
 
 //! A platform agnostic Rust driver for the Bosch BME280 and BMP280, based on the
 //! [`embedded-hal`](https://github.com/japaric/embedded-hal) traits.
@@ -63,8 +64,14 @@
 //! ```
 
 use core::marker::PhantomData;
+#[cfg(feature = "with-std")]
+use derive_more::Display;
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
+#[cfg(feature = "with-std")]
+use std::error;
+#[cfg(feature = "with-std")]
+use std::fmt;
 
 #[cfg(feature = "serde")]
 use serde::Serialize;
@@ -137,6 +144,8 @@ macro_rules! set_bits {
 }
 
 /// BME280 errors
+///
+#[cfg_attr(feature = "with-std", derive(Display))]
 #[derive(Debug)]
 pub enum Error<E> {
     /// Failed to compensate a raw measurement
@@ -150,6 +159,9 @@ pub enum Error<E> {
     /// Chip ID doesn't match expected value
     UnsupportedChip,
 }
+
+#[cfg(feature = "with-std")]
+impl<T: fmt::Debug + fmt::Display> error::Error for Error<T> {}
 
 /// BME280 operating mode
 #[derive(Debug, Copy, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ pub enum Error<E> {
 }
 
 #[cfg(feature = "with-std")]
+/// Enabling the `with-std` feature will allow standard error handling
 impl<T: fmt::Debug + fmt::Display> error::Error for Error<T> {}
 
 /// BME280 operating mode


### PR DESCRIPTION
Allows the user to early return errors with `?`, like
```rust
fn main() -> Result<(), Box<dyn Error>> {
    let opt = Opt::from_args();
    let i2c_bus = I2cdev::new(opt.i2c_bus_path)?; // here
    let mut sensor = BME280::new(i2c_bus, opt.i2c_address, Delay);
    sensor.init()?; // here
    let measurements = sensor.measure()?; //here
    println!("{:?}", measurements);
    Ok(())
}
```