### PR TITLE
Borrow Delay instead of transferring ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ use bme280::BME280;
 let i2c_bus = I2cdev::new("/dev/i2c-1").unwrap();
 
 // initialize the BME280 using the primary I2C address 0x76
-let mut bme280 = BME280::new_primary(i2c_bus, Delay);
+let mut bme280 = BME280::new_primary(i2c_bus);
 
 // or, initialize the BME280 using the secondary I2C address 0x77
-// let mut bme280 = BME280::new_secondary(i2c_bus, Delay);
+// let mut bme280 = BME280::new_secondary(i2c_bus);
 
 // or, initialize the BME280 using a custom I2C address
 // let bme280_i2c_addr = 0x88;
-// let mut bme280 = BME280::new(i2c_bus, bme280_i2c_addr, Delay);
+// let mut bme280 = BME280::new(i2c_bus, bme280_i2c_addr);
 
 // initialize the sensor
-bme280.init().unwrap();
+bme280.init(&mut Delay).unwrap();
 
 // measure temperature, pressure, and humidity
-let measurements = bme280.measure().unwrap();
+let measurements = bme280.measure(&mut Delay).unwrap();
 
 println!("Relative Humidity = {}%", measurements.humidity);
 println!("Temperature = {} deg C", measurements.temperature);


### PR DESCRIPTION
Borrow Delay instead of transferring ownership which allows the Delay instance to still be used later in a program using the bme280 crate.