### PR TITLE
Update to embedded-hal 1.0.0-alpha.8 and add optional support for embedded-hal-async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,12 @@ edition = "2018"
 name = "bme280"
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.7"
+embedded-hal = "=1.0.0-alpha.8"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 defmt = { version = "0.3.2", optional = true }
 derive_more = { version = "0.99.17", optional = true}
+embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]
 cortex-m-rtic = "1.0.0"
@@ -26,12 +28,15 @@ defmt-rtt = "0.3.0"
 panic-semihosting = "0.6"
 
 [dev-dependencies.stm32f4xx-hal]
-version = "0.12.0"
+version = "0.13.2"
 features = ["stm32f411"]
 
 [features]
+default = ["sync"]
 with_defmt = ["defmt"]
 with_std = ["derive_more"]
+sync = []
+async = ["embedded-hal-async"]
 
 [[example]]
 name = "rtic"

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,25 +1,58 @@
 //! BME280 driver for sensors attached via I2C.
 
+#[cfg(feature = "sync")]
 use embedded_hal::delay::blocking::DelayUs;
-use embedded_hal::i2c::{blocking::I2c, ErrorType};
+#[cfg(feature = "async")]
+use embedded_hal_async::delay::DelayUs as AsyncDelayUs;
+use embedded_hal::i2c::ErrorType;
+#[cfg(feature = "sync")]
+use embedded_hal::i2c::blocking::I2c;
+#[cfg(feature = "async")]
+use embedded_hal_async::i2c::I2c as AsyncI2c;
+#[cfg(feature = "async")]
+use core::future::Future;
 
 use super::{
-    BME280Common, Configuration, Error, IIRFilter, Interface, Measurements, Oversampling,
+    Configuration, Error, IIRFilter, Measurements, Oversampling,
     BME280_H_CALIB_DATA_LEN, BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN,
 };
+#[cfg(feature = "sync")]
+use super::{BME280Common, Interface};
+#[cfg(feature = "async")]
+use super::{AsyncBME280Common, AsyncInterface};
 
 const BME280_I2C_ADDR_PRIMARY: u8 = 0x76;
 const BME280_I2C_ADDR_SECONDARY: u8 = 0x77;
 
 /// Representation of a BME280
+#[maybe_async_cfg::maybe(
+    sync(
+        feature = "sync",
+        self = "BME280",
+        idents(AsyncBME280Common(sync = "BME280Common"))
+    ),
+    async(feature = "async", keep_self)
+)]
 #[derive(Debug, Default)]
-pub struct BME280<I2C> {
-    common: BME280Common<I2CInterface<I2C>>,
+pub struct AsyncBME280<I2C> {
+    common: AsyncBME280Common<I2CInterface<I2C>>,
 }
 
-impl<I2C> BME280<I2C>
+#[maybe_async_cfg::maybe(
+    sync(
+        feature = "sync",
+        self = "BME280",
+        idents(
+            AsyncI2c(sync = "I2c"),
+            AsyncDelayUs(sync = "DelayUs"),
+            AsyncBME280Common(sync = "BME280Common"),
+        )
+    ),
+    async(feature = "async", keep_self)
+)]
+impl<I2C> AsyncBME280<I2C>
 where
-    I2C: I2c + ErrorType,
+    I2C: AsyncI2c + ErrorType,
 {
     /// Create a new BME280 struct using the primary I²C address `0x76`
     pub fn new_primary(i2c: I2C) -> Self {
@@ -33,8 +66,8 @@ where
 
     /// Create a new BME280 struct using a custom I²C address
     pub fn new(i2c: I2C, address: u8) -> Self {
-        BME280 {
-            common: BME280Common {
+        Self {
+            common: AsyncBME280Common {
                 interface: I2CInterface { i2c, address },
                 calibration: None,
             },
@@ -44,7 +77,7 @@ where
     /// Initializes the BME280.
     /// This configures 2x temperature oversampling, 16x pressure oversampling, and the IIR filter
     /// coefficient 16.
-    pub fn init<D: DelayUs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
+    pub async fn init<D: AsyncDelayUs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
         self.common.init(
             delay,
             Configuration::default()
@@ -52,24 +85,24 @@ where
                 .with_pressure_oversampling(Oversampling::Oversampling16X)
                 .with_temperature_oversampling(Oversampling::Oversampling2X)
                 .with_iir_filter(IIRFilter::Coefficient16),
-        )
+        ).await
     }
 
     /// Initializes the BME280, applying the given configuration.
-    pub fn init_with_config<D: DelayUs>(
+    pub async fn init_with_config<D: AsyncDelayUs>(
         &mut self,
         delay: &mut D,
         config: Configuration,
     ) -> Result<(), Error<I2C::Error>> {
-        self.common.init(delay, config)
+        self.common.init(delay, config).await
     }
 
     /// Captures and processes sensor data for temperature, pressure, and humidity
-    pub fn measure<D: DelayUs>(
+    pub async fn measure<D: AsyncDelayUs>(
         &mut self,
         delay: &mut D,
     ) -> Result<Measurements<I2C::Error>, Error<I2C::Error>> {
-        self.common.measure(delay)
+        self.common.measure(delay).await
     }
 }
 
@@ -82,6 +115,7 @@ struct I2CInterface<I2C> {
     address: u8,
 }
 
+#[cfg(feature = "sync")]
 impl<I2C> Interface for I2CInterface<I2C>
 where
     I2C: I2c + ErrorType,
@@ -133,5 +167,85 @@ where
         self.i2c
             .write(self.address, &[register, payload])
             .map_err(Error::Bus)
+    }
+}
+
+#[cfg(feature = "async")]
+impl<I2C> AsyncInterface for I2CInterface<I2C>
+where
+    I2C: AsyncI2c + ErrorType,
+{
+    type Error = I2C::Error;
+
+    type ReadRegisterFuture<'a> = impl Future<Output = Result<u8, Error<Self::Error>>>
+    where
+        I2C: 'a;
+    fn read_register<'a>(&'a mut self, register: u8) -> Self::ReadRegisterFuture<'a> {
+        async move {
+            let mut data: [u8; 1] = [0];
+            self.i2c
+                .write_read(self.address, &[register], &mut data).await
+                .map_err(Error::Bus)?;
+            Ok(data[0])
+        }
+    }
+
+    type ReadDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>>>
+    where
+        I2C: 'a;
+    fn read_data<'a>(
+        &'a mut self,
+        register: u8,
+    ) -> Self::ReadDataFuture<'a> {
+        async move {
+            let mut data = [0; BME280_P_T_H_DATA_LEN];
+            self.i2c
+                .write_read(self.address, &[register], &mut data).await
+                .map_err(Error::Bus)?;
+            Ok(data)
+        }
+    }
+
+    type ReadPtCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>>>
+    where
+        I2C: 'a;
+    fn read_pt_calib_data<'a>(
+        &'a mut self,
+        register: u8,
+    ) -> Self::ReadPtCalibDataFuture<'a> {
+        async move {
+            let mut data = [0; BME280_P_T_CALIB_DATA_LEN];
+            self.i2c
+                .write_read(self.address, &[register], &mut data).await
+                .map_err(Error::Bus)?;
+            Ok(data)
+        }
+    }
+
+    type ReadHCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>>>
+    where
+        I2C: 'a;
+    fn read_h_calib_data<'a>(
+        &'a mut self,
+        register: u8,
+    ) -> Self::ReadHCalibDataFuture<'a> {
+        async move {
+            let mut data = [0; BME280_H_CALIB_DATA_LEN];
+            self.i2c
+                .write_read(self.address, &[register], &mut data).await
+                .map_err(Error::Bus)?;
+            Ok(data)
+        }
+    }
+
+    type WriteRegisterFuture<'a> = impl Future<Output = Result<(), Error<Self::Error>>>
+    where
+        I2C: 'a;
+    fn write_register<'a>(&'a mut self, register: u8, payload: u8) -> Self::WriteRegisterFuture<'a> {
+        async move {
+            self.i2c
+                .write(self.address, &[register, payload]).await
+                .map_err(Error::Bus)
+        }
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,25 +1,25 @@
 //! BME280 driver for sensors attached via I2C.
 
-#[cfg(feature = "sync")]
-use embedded_hal::delay::blocking::DelayUs;
-#[cfg(feature = "async")]
-use embedded_hal_async::delay::DelayUs as AsyncDelayUs;
-use embedded_hal::i2c::ErrorType;
-#[cfg(feature = "sync")]
-use embedded_hal::i2c::blocking::I2c;
-#[cfg(feature = "async")]
-use embedded_hal_async::i2c::I2c as AsyncI2c;
 #[cfg(feature = "async")]
 use core::future::Future;
-
-use super::{
-    Configuration, Error, IIRFilter, Measurements, Oversampling,
-    BME280_H_CALIB_DATA_LEN, BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN,
-};
 #[cfg(feature = "sync")]
-use super::{BME280Common, Interface};
+use embedded_hal::delay::blocking::DelayUs;
+#[cfg(feature = "sync")]
+use embedded_hal::i2c::blocking::I2c;
+use embedded_hal::i2c::ErrorType;
+#[cfg(feature = "async")]
+use embedded_hal_async::delay::DelayUs as AsyncDelayUs;
+#[cfg(feature = "async")]
+use embedded_hal_async::i2c::I2c as AsyncI2c;
+
 #[cfg(feature = "async")]
 use super::{AsyncBME280Common, AsyncInterface};
+#[cfg(feature = "sync")]
+use super::{BME280Common, Interface};
+use super::{
+    Configuration, Error, IIRFilter, Measurements, Oversampling, BME280_H_CALIB_DATA_LEN,
+    BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN,
+};
 
 const BME280_I2C_ADDR_PRIMARY: u8 = 0x76;
 const BME280_I2C_ADDR_SECONDARY: u8 = 0x77;
@@ -78,14 +78,16 @@ where
     /// This configures 2x temperature oversampling, 16x pressure oversampling, and the IIR filter
     /// coefficient 16.
     pub async fn init<D: AsyncDelayUs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
-        self.common.init(
-            delay,
-            Configuration::default()
-                .with_humidity_oversampling(Oversampling::Oversampling1X)
-                .with_pressure_oversampling(Oversampling::Oversampling16X)
-                .with_temperature_oversampling(Oversampling::Oversampling2X)
-                .with_iir_filter(IIRFilter::Coefficient16),
-        ).await
+        self.common
+            .init(
+                delay,
+                Configuration::default()
+                    .with_humidity_oversampling(Oversampling::Oversampling1X)
+                    .with_pressure_oversampling(Oversampling::Oversampling16X)
+                    .with_temperature_oversampling(Oversampling::Oversampling2X)
+                    .with_iir_filter(IIRFilter::Coefficient16),
+            )
+            .await
     }
 
     /// Initializes the BME280, applying the given configuration.
@@ -184,7 +186,8 @@ where
         async move {
             let mut data: [u8; 1] = [0];
             self.i2c
-                .write_read(self.address, &[register], &mut data).await
+                .write_read(self.address, &[register], &mut data)
+                .await
                 .map_err(Error::Bus)?;
             Ok(data[0])
         }
@@ -193,14 +196,12 @@ where
     type ReadDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>>>
     where
         I2C: 'a;
-    fn read_data<'a>(
-        &'a mut self,
-        register: u8,
-    ) -> Self::ReadDataFuture<'a> {
+    fn read_data<'a>(&'a mut self, register: u8) -> Self::ReadDataFuture<'a> {
         async move {
             let mut data = [0; BME280_P_T_H_DATA_LEN];
             self.i2c
-                .write_read(self.address, &[register], &mut data).await
+                .write_read(self.address, &[register], &mut data)
+                .await
                 .map_err(Error::Bus)?;
             Ok(data)
         }
@@ -209,14 +210,12 @@ where
     type ReadPtCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>>>
     where
         I2C: 'a;
-    fn read_pt_calib_data<'a>(
-        &'a mut self,
-        register: u8,
-    ) -> Self::ReadPtCalibDataFuture<'a> {
+    fn read_pt_calib_data<'a>(&'a mut self, register: u8) -> Self::ReadPtCalibDataFuture<'a> {
         async move {
             let mut data = [0; BME280_P_T_CALIB_DATA_LEN];
             self.i2c
-                .write_read(self.address, &[register], &mut data).await
+                .write_read(self.address, &[register], &mut data)
+                .await
                 .map_err(Error::Bus)?;
             Ok(data)
         }
@@ -225,14 +224,12 @@ where
     type ReadHCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>>>
     where
         I2C: 'a;
-    fn read_h_calib_data<'a>(
-        &'a mut self,
-        register: u8,
-    ) -> Self::ReadHCalibDataFuture<'a> {
+    fn read_h_calib_data<'a>(&'a mut self, register: u8) -> Self::ReadHCalibDataFuture<'a> {
         async move {
             let mut data = [0; BME280_H_CALIB_DATA_LEN];
             self.i2c
-                .write_read(self.address, &[register], &mut data).await
+                .write_read(self.address, &[register], &mut data)
+                .await
                 .map_err(Error::Bus)?;
             Ok(data)
         }
@@ -241,10 +238,15 @@ where
     type WriteRegisterFuture<'a> = impl Future<Output = Result<(), Error<Self::Error>>>
     where
         I2C: 'a;
-    fn write_register<'a>(&'a mut self, register: u8, payload: u8) -> Self::WriteRegisterFuture<'a> {
+    fn write_register<'a>(
+        &'a mut self,
+        register: u8,
+        payload: u8,
+    ) -> Self::WriteRegisterFuture<'a> {
         async move {
             self.i2c
-                .write(self.address, &[register, payload]).await
+                .write(self.address, &[register, payload])
+                .await
                 .map_err(Error::Bus)
         }
     }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,33 +1,66 @@
 //! BME280 driver for sensors attached via SPI.
 
+#[cfg(feature = "sync")]
 use embedded_hal::delay::blocking::DelayUs;
-use embedded_hal::digital::blocking::OutputPin;
-use embedded_hal::spi::blocking::Transfer;
+#[cfg(feature = "async")]
+use embedded_hal_async::delay::DelayUs as AsyncDelayUs;
+#[cfg(feature = "sync")]
+use embedded_hal::spi::blocking::{SpiBus, SpiDevice};
+#[cfg(feature = "async")]
+use embedded_hal_async::spi::{SpiDevice as AsyncSpiDevice, SpiBus as AsyncSpiBus};
+#[cfg(feature = "async")]
+use core::future::Future;
 
 use super::{
-    BME280Common, Configuration, Error, IIRFilter, Interface, Measurements, Oversampling,
+    Configuration, Error, IIRFilter, Measurements, Oversampling,
     BME280_H_CALIB_DATA_LEN, BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN,
 };
+#[cfg(feature = "sync")]
+use super::{BME280Common, Interface};
+#[cfg(feature = "async")]
+use super::{AsyncBME280Common, AsyncInterface};
 
 /// Representation of a BME280
+#[maybe_async_cfg::maybe(
+    sync(
+        feature = "sync",
+        self = "BME280",
+        idents(
+            AsyncBME280Common(sync = "BME280Common"),
+            AsyncSPIInterface(sync = "SPIInterface"),
+        )
+    ),
+    async(feature = "async", keep_self)
+)]
 #[derive(Debug, Default)]
-pub struct BME280<SPI, CS> {
-    common: BME280Common<SPIInterface<SPI, CS>>,
+pub struct AsyncBME280<SPI> {
+    common: AsyncBME280Common<AsyncSPIInterface<SPI>>,
 }
 
-impl<SPI, CS, SPIE, PinE> BME280<SPI, CS>
+#[maybe_async_cfg::maybe(
+    sync(
+        feature = "sync",
+        self = "BME280",
+        idents(
+            AsyncSpiDevice(sync = "SpiDevice"),
+            AsyncSpiBus(sync = "SpiBus"),
+            AsyncSPIInterface(sync = "SPIInterface"),
+            AsyncDelayUs(sync = "DelayUs"),
+            AsyncBME280Common(sync = "BME280Common"),
+        )
+    ),
+    async(feature = "async", keep_self)
+)]
+impl<SPI, SPIE> AsyncBME280<SPI>
 where
-    SPI: Transfer<u8, Error = SPIE>,
-    CS: OutputPin<Error = PinE>,
+    SPI: AsyncSpiDevice<Error = SPIE>,
+    SPI::Bus: AsyncSpiBus<u8>,
 {
     /// Create a new BME280 struct
-    pub fn new(spi: SPI, mut cs: CS) -> Result<Self, Error<SPIError<SPIE, PinE>>> {
-        // Deassert chip-select.
-        cs.set_high().map_err(|e| Error::Bus(SPIError::Pin(e)))?;
-
-        Ok(BME280 {
-            common: BME280Common {
-                interface: SPIInterface { spi, cs },
+    pub fn new(spi: SPI) -> Result<Self, Error<SPIError<SPIE>>> {
+        Ok(Self {
+            common: AsyncBME280Common {
+                interface: AsyncSPIInterface { spi },
                 calibration: None,
             },
         })
@@ -36,7 +69,7 @@ where
     /// Initializes the BME280.
     /// This configures 2x temperature oversampling, 16x pressure oversampling, and the IIR filter
     /// coefficient 16.
-    pub fn init<D: DelayUs>(&mut self, delay: &mut D) -> Result<(), Error<SPIError<SPIE, PinE>>> {
+    pub async fn init<D: AsyncDelayUs>(&mut self, delay: &mut D) -> Result<(), Error<SPIError<SPIE>>> {
         self.common.init(
             delay,
             Configuration::default()
@@ -44,42 +77,48 @@ where
                 .with_pressure_oversampling(Oversampling::Oversampling16X)
                 .with_temperature_oversampling(Oversampling::Oversampling2X)
                 .with_iir_filter(IIRFilter::Coefficient16),
-        )
+        ).await
     }
 
     /// Initializes the BME280, applying the given configuration.
-    pub fn init_with_config<D: DelayUs>(
+    pub async fn init_with_config<D: AsyncDelayUs>(
         &mut self,
         delay: &mut D,
         config: Configuration,
-    ) -> Result<(), Error<SPIError<SPIE, PinE>>> {
-        self.common.init(delay, config)
+    ) -> Result<(), Error<SPIError<SPIE>>> {
+        self.common.init(delay, config).await
     }
 
     /// Captures and processes sensor data for temperature, pressure, and humidity
-    pub fn measure<D: DelayUs>(
+    pub async fn measure<D: AsyncDelayUs>(
         &mut self,
         delay: &mut D,
-    ) -> Result<Measurements<SPIError<SPIE, PinE>>, Error<SPIError<SPIE, PinE>>> {
-        self.common.measure(delay)
+    ) -> Result<Measurements<SPIError<SPIE>>, Error<SPIError<SPIE>>> {
+        self.common.measure(delay).await
     }
 }
 
 /// Register access functions for SPI
+#[maybe_async_cfg::maybe(
+sync(
+    feature = "sync",
+    self = "SPIInterface",
+),
+async(feature = "async", keep_self)
+)]
 #[derive(Debug, Default)]
-struct SPIInterface<SPI, CS> {
+struct AsyncSPIInterface<SPI> {
     /// concrete SPI device implementation
     spi: SPI,
-    /// chip-select pin
-    cs: CS,
 }
 
-impl<SPI, CS> Interface for SPIInterface<SPI, CS>
+#[cfg(feature = "sync")]
+impl<SPI> Interface for SPIInterface<SPI>
 where
-    SPI: Transfer<u8>,
-    CS: OutputPin,
+    SPI: SpiDevice,
+    SPI::Bus: SpiBus<u8>,
 {
-    type Error = SPIError<SPI::Error, CS::Error>;
+    type Error = SPIError<SPI::Error>;
 
     fn read_register(&mut self, register: u8) -> Result<u8, Error<Self::Error>> {
         let mut result = [0u8];
@@ -115,49 +154,124 @@ where
     }
 
     fn write_register(&mut self, register: u8, payload: u8) -> Result<(), Error<Self::Error>> {
-        self.cs
-            .set_low()
-            .map_err(|e| Error::Bus(SPIError::Pin(e)))?;
         // If the first bit is 0, the register is written.
         let transfer = [register & 0x7f, payload];
         self.spi
             .transfer(&mut [], &transfer)
             .map_err(|e| Error::Bus(SPIError::SPI(e)))?;
-        self.cs
-            .set_high()
-            .map_err(|e| Error::Bus(SPIError::Pin(e)))?;
         Ok(())
     }
 }
 
-impl<SPI, CS> SPIInterface<SPI, CS>
+#[cfg(feature = "async")]
+impl<SPI> AsyncInterface for AsyncSPIInterface<SPI>
 where
-    SPI: Transfer<u8>,
-    CS: OutputPin,
+    SPI: AsyncSpiDevice,
+    SPI::Bus: AsyncSpiBus<u8>,
 {
-    fn read_any_register(
+    type Error = SPIError<SPI::Error>;
+
+    type ReadRegisterFuture<'a> = impl Future<Output = Result<u8, Error<Self::Error>>>
+    where
+        SPI: 'a;
+    fn read_register<'a>(&'a mut self, register: u8) -> Self::ReadRegisterFuture<'a> {
+        async move {
+            let mut result = [0u8];
+            self.read_any_register(register, &mut result).await?;
+            Ok(result[0])
+        }
+    }
+
+    type ReadDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>>>
+    where
+        SPI: 'a;
+    fn read_data<'a>(
+        &'a mut self,
+        register: u8,
+    ) -> Self::ReadDataFuture<'a> {
+        async move {
+            let mut data = [0; BME280_P_T_H_DATA_LEN];
+            self.read_any_register(register, &mut data).await?;
+            Ok(data)
+        }
+    }
+
+    type ReadPtCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>>>
+    where
+        SPI: 'a;
+    fn read_pt_calib_data<'a>(
+        &'a mut self,
+        register: u8,
+    ) -> Self::ReadPtCalibDataFuture<'a> {
+        async move {
+            let mut data = [0; BME280_P_T_CALIB_DATA_LEN];
+            self.read_any_register(register, &mut data).await?;
+            Ok(data)
+        }
+    }
+
+    type ReadHCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>>>
+    where
+        SPI: 'a;
+    fn read_h_calib_data<'a>(
+        &'a mut self,
+        register: u8,
+    ) -> Self::ReadHCalibDataFuture<'a> {
+        async move {
+            let mut data = [0; BME280_H_CALIB_DATA_LEN];
+            self.read_any_register(register, &mut data).await?;
+            Ok(data)
+        }
+    }
+
+    type WriteRegisterFuture<'a> = impl Future<Output = Result<(), Error<Self::Error>>>
+    where
+        SPI: 'a;
+    fn write_register<'a>(&'a mut self, register: u8, payload: u8) -> Self::WriteRegisterFuture<'a> {
+        async move {
+            // If the first bit is 0, the register is written.
+            let transfer = [register & 0x7f, payload];
+            self.spi
+                .transfer(&mut [], &transfer).await
+                .map_err(|e| Error::Bus(SPIError::SPI(e)))?;
+            Ok(())
+        }
+    }
+}
+
+#[maybe_async_cfg::maybe(
+    sync(
+        feature = "sync",
+        self = "SPIInterface",
+        idents(
+            AsyncSpiDevice(sync = "SpiDevice"),
+            AsyncSpiBus(sync = "SpiBus"),
+        )
+    ),
+    async(feature = "async", keep_self)
+)]
+impl<SPI> AsyncSPIInterface<SPI>
+where
+    SPI: AsyncSpiDevice,
+    SPI::Bus: AsyncSpiBus<u8>,
+{
+    async fn read_any_register(
         &mut self,
         register: u8,
         data: &mut [u8],
-    ) -> Result<(), Error<SPIError<SPI::Error, CS::Error>>> {
-        self.cs
-            .set_low()
-            .map_err(|e| Error::Bus(SPIError::Pin(e)))?;
+    ) -> Result<(), Error<SPIError<SPI::Error>>> {
         self.spi
-            .transfer(data, &[register])
+            .transfer(data, &[register]).await
             .map_err(|e| Error::Bus(SPIError::SPI(e)))?;
-        self.cs
-            .set_high()
-            .map_err(|e| Error::Bus(SPIError::Pin(e)))?;
         Ok(())
     }
 }
 
+
+
 /// Error which occurred during an SPI transaction
 #[derive(Clone, Copy, Debug)]
-pub enum SPIError<SPIE, PinE> {
+pub enum SPIError<SPIE> {
     /// The SPI implementation returned an error
     SPI(SPIE),
-    /// The GPIO implementation returned an error which changing the chip-select pin state
-    Pin(PinE),
 }


### PR DESCRIPTION
Note that the example won't compile until https://github.com/stm32-rs/stm32f4xx-hal/pull/510 is merged, since they use `stm32f4xx-hal` and it's currently on 1.0.0-alpha.7 (not that it seemingly compiles out of the box, anyway). Not sure what to do before that's merged (block merging this, I guess?).