### PR TITLE
Fix sign extension of h4 and h5 calibration value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -643,8 +643,8 @@ fn parse_calib_data(
     let dig_h1 = pt_data[25];
     let dig_h2 = concat_bytes!(h_data[1], h_data[0]) as i16;
     let dig_h3 = h_data[2];
-    let dig_h4 = (h_data[3] as i16 * 16) | ((h_data[4] as i16) & 0x0F);
-    let dig_h5 = (h_data[5] as i16 * 16) | ((h_data[4] as i16) >> 4);
+    let dig_h4 = (h_data[3] as i8 as i16 * 16) | ((h_data[4] as i8 as i16) & 0x0F);
+    let dig_h5 = (h_data[5] as i8 as i16 * 16) | (((h_data[4] as i8 as i16) & 0xF0) >> 4);
     let dig_h6 = h_data[6] as i8;
 
     CalibrationData {


### PR DESCRIPTION
The 12 bit signed values h4 and h5 are meant to be sign extended to signed 16 bit.
The data sheet is ambiguous about this, but the official driver provided by Bosch
does sign extension:

https://github.com/BoschSensortec/BME280_driver/blob/c47f06eb44fc96970f0abfcc941ec16425b2a9e6/bme280.c#L1528

Also see this example code for why this step cast makes a difference:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=99d2c26c65a324288c1a9c3a08eeb0dc

`h_data[4]` doesn't strictly need this step cast, but I included it for symmetry. The new mask `0xF0` is necessary with this sign extension cast.

This bug is very similar to this other bug in this other crate:
https://github.com/newAM/bme280-multibus/pull/22
