### PR TITLE
Fix Spi and embedded-hal version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 name = "bme280"
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.7"
+embedded-hal = "=1.0.0-alpha.8"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 defmt = { version = "0.3.2", optional = true }
 derive_more = { version = "0.99.17", optional = true}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,6 +1,6 @@
 //! BME280 driver for sensors attached via SPI.
 
-use embedded_hal::spi::blocking::{SpiBusRead, SpiBusWrite};
+use embedded_hal::spi::blocking::{SpiBus, SpiBusWrite, SpiBusRead};
 use embedded_hal::{delay::blocking::DelayUs, spi::blocking::SpiDevice};
 
 use super::{
@@ -17,7 +17,7 @@ pub struct BME280<DEVICE> {
 impl<DEVICE> BME280<DEVICE>
 where
     DEVICE: SpiDevice,
-    DEVICE::Bus: SpiBusWrite + SpiBusRead,
+    DEVICE::Bus: SpiBus,
 {
     /// Create a new BME280 struct
     pub fn new(device: DEVICE) -> Self {
@@ -71,7 +71,7 @@ struct SPIInterface<DEVICE> {
 impl<DEVICE> Interface for SPIInterface<DEVICE>
 where
     DEVICE: SpiDevice,
-    DEVICE::Bus: SpiBusWrite + SpiBusRead,
+    DEVICE::Bus: SpiBus,
 {
     type Error = DEVICE::Error;
 
@@ -118,7 +118,7 @@ where
 impl<DEVICE> SPIInterface<DEVICE>
 where
     DEVICE: SpiDevice,
-    DEVICE::Bus: SpiBusWrite + SpiBusRead,
+    DEVICE::Bus: SpiBus,
 {
     fn read_any_register(
         &mut self,


### PR DESCRIPTION
* Fixes SPI not working
* Bumps Embedded-hal to 1.0-alpha.8 that introduces a new trait called SpiDevice that should be used instead of (SpiBus, CS). This version is also used in the stm32f4xx_hal

Closes #25 

I could also add an example for SPI, but I'll leave that for another PR