### PR TITLE
Fixed SPI for sync implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ defmt-rtt = "0.3.0"
 panic-semihosting = "0.6"
 
 [dev-dependencies.stm32f4xx-hal]
-version = "0.13.2"
+version = "0.14.0"
 features = ["stm32f411"]
 
 [features]

--- a/examples/rtic.rs
+++ b/examples/rtic.rs
@@ -14,8 +14,8 @@ mod app {
         timer::delay::Delay,
     };
 
-    type Scl = Pin<Alternate<OpenDrain, 4>, 'B', 6>;
-    type Sda = Pin<Alternate<OpenDrain, 4>, 'B', 7>;
+    type Scl = Pin<'B', 6, Alternate<4, OpenDrain>>;
+    type Sda = Pin<'B', 7, Alternate<4, OpenDrain>>;
 
     #[shared]
     struct Shared {}


### PR DESCRIPTION
This PR fixes SPI communication for sync implementation of the BME280 driver. I didn't fix async impl, because I couldn't get it to compile. I'd need to be investigate the problem first and I don't have much time right now. @VersBinarii try to run 
`cargo b --features=async` and let me know what you get.

I also upgraded stm32f4xx_hal dev-dependency because I build anything due to conflicts

# Related issues
* #25

# Testing
Tested on stm32f446re and bmp280
```rust
let sck = gpiob.pb10.into_alternate();
let miso = gpioc.pc2.into_alternate();
let mosi = gpioc.pc1.into_alternate();
let cs = gpioc.pc3.into_push_pull_output();
let reset = gpioc.pc0.into_push_pull_output();

let spi = device
    .SPI2
    .spi((sck, miso, mosi), embedded_hal::spi::MODE_0, 8.MHz(), &clocks);
            
let device = embedded_hal::spi::blocking::ExclusiveDevice::new(spi, cs);
let mut bme = BME280::new(device).unwrap();
bme.init(&mut delay).unwrap();
let m = bme.measure(&mut delay).unwrap();
defmt::println!("{}", defmt::Debug2Format(&m));
```
Output:
```rust
Measurements { temperature: 26.200403, pressure: 100920.3, humidity: 0.0
```
Note: Humidity == 0.0 to be expected, bmp280 doesn't support it.