### PR TITLE
feat: update embedded-hal to 1.0.0-alpha.10 and embedded-hal-async to 0.2.0-alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 name = "bme280"
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.8"
+embedded-hal = "=1.0.0-alpha.10"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 defmt = { version = "0.3.2", optional = true }
 derive_more = { version = "0.99.17", optional = true}
-embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
 maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -3,10 +3,10 @@
 #[cfg(feature = "async")]
 use core::future::Future;
 #[cfg(feature = "sync")]
-use embedded_hal::delay::blocking::DelayUs;
-#[cfg(feature = "sync")]
-use embedded_hal::i2c::blocking::I2c;
+use embedded_hal::delay::DelayUs;
 use embedded_hal::i2c::ErrorType;
+#[cfg(feature = "sync")]
+use embedded_hal::i2c::I2c;
 #[cfg(feature = "async")]
 use embedded_hal_async::delay::DelayUs as AsyncDelayUs;
 #[cfg(feature = "async")]
@@ -179,7 +179,7 @@ where
 {
     type Error = I2C::Error;
 
-    type ReadRegisterFuture<'a> = impl Future<Output = Result<u8, Error<Self::Error>>>
+    type ReadRegisterFuture<'a> = impl Future<Output = Result<u8, Error<Self::Error>>> + 'a
     where
         I2C: 'a;
     fn read_register<'a>(&'a mut self, register: u8) -> Self::ReadRegisterFuture<'a> {
@@ -193,7 +193,7 @@ where
         }
     }
 
-    type ReadDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>>>
+    type ReadDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>>> + 'a
     where
         I2C: 'a;
     fn read_data<'a>(&'a mut self, register: u8) -> Self::ReadDataFuture<'a> {
@@ -207,7 +207,7 @@ where
         }
     }
 
-    type ReadPtCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>>>
+    type ReadPtCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>>> + 'a
     where
         I2C: 'a;
     fn read_pt_calib_data<'a>(&'a mut self, register: u8) -> Self::ReadPtCalibDataFuture<'a> {
@@ -221,7 +221,7 @@ where
         }
     }
 
-    type ReadHCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>>>
+    type ReadHCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>>> + 'a
     where
         I2C: 'a;
     fn read_h_calib_data<'a>(&'a mut self, register: u8) -> Self::ReadHCalibDataFuture<'a> {
@@ -235,7 +235,7 @@ where
         }
     }
 
-    type WriteRegisterFuture<'a> = impl Future<Output = Result<(), Error<Self::Error>>>
+    type WriteRegisterFuture<'a> = impl Future<Output = Result<(), Error<Self::Error>>> + 'a
     where
         I2C: 'a;
     fn write_register<'a>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@
 #![cfg_attr(
     feature = "async",
     feature(generic_associated_types),
-    feature(type_alias_impl_trait)
+    feature(type_alias_impl_trait),
+    feature(impl_trait_in_assoc_type)
 )]
 
 //! A platform agnostic Rust driver for the Bosch BME280 and BMP280, based on the
@@ -75,7 +76,7 @@ pub mod spi;
 use core::future::Future;
 use core::marker::PhantomData;
 #[cfg(feature = "sync")]
-use embedded_hal::delay::blocking::DelayUs;
+use embedded_hal::delay::DelayUs;
 #[cfg(feature = "async")]
 use embedded_hal_async::delay::DelayUs as AsyncDelayUs;
 
@@ -587,7 +588,7 @@ where
         self.interface
             .write_register(BME280_RESET_ADDR, BME280_SOFT_RESET_CMD)
             .await?;
-        delay.delay_ms(2).await.map_err(|_| Error::Delay)?; // startup time is 2ms
+        delay.delay_ms(2).await; // startup time is 2ms
         Ok(())
     }
 
@@ -688,7 +689,7 @@ where
         delay: &mut D,
     ) -> Result<Measurements<I::Error>, Error<I::Error>> {
         self.forced(delay).await?;
-        delay.delay_ms(40).await.map_err(|_| Error::Delay)?; // await measurement
+        delay.delay_ms(40).await; // await measurement
         let measurements = self.interface.read_data(BME280_DATA_ADDR).await?;
         match self.calibration.as_mut() {
             Some(calibration) => {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -3,13 +3,13 @@
 #[cfg(feature = "async")]
 use core::future::Future;
 #[cfg(feature = "sync")]
-use embedded_hal::delay::blocking::DelayUs;
+use embedded_hal::delay::DelayUs;
 #[cfg(feature = "sync")]
-use embedded_hal::spi::blocking::{SpiBus, SpiDevice};
+use embedded_hal::spi::SpiDevice;
 #[cfg(feature = "async")]
 use embedded_hal_async::delay::DelayUs as AsyncDelayUs;
 #[cfg(feature = "async")]
-use embedded_hal_async::spi::{SpiBus as AsyncSpiBus, SpiDevice as AsyncSpiDevice};
+use embedded_hal_async::spi::SpiDevice as AsyncSpiDevice;
 
 #[cfg(feature = "async")]
 use super::{AsyncBME280Common, AsyncInterface};
@@ -54,7 +54,6 @@ pub struct AsyncBME280<SPI> {
 impl<SPI, SPIE> AsyncBME280<SPI>
 where
     SPI: AsyncSpiDevice<Error = SPIE>,
-    SPI::Bus: AsyncSpiBus<u8>,
 {
     /// Create a new BME280 struct
     pub fn new(spi: SPI) -> Result<Self, Error<SPIError<SPIE>>> {
@@ -118,7 +117,6 @@ struct AsyncSPIInterface<SPI> {
 impl<SPI> Interface for SPIInterface<SPI>
 where
     SPI: SpiDevice,
-    SPI::Bus: SpiBus<u8>,
 {
     type Error = SPIError<SPI::Error>;
 
@@ -169,11 +167,10 @@ where
 impl<SPI> AsyncInterface for AsyncSPIInterface<SPI>
 where
     SPI: AsyncSpiDevice,
-    SPI::Bus: AsyncSpiBus<u8>,
 {
     type Error = SPIError<SPI::Error>;
 
-    type ReadRegisterFuture<'a> = impl Future<Output = Result<u8, Error<Self::Error>>>
+    type ReadRegisterFuture<'a> = impl Future<Output = Result<u8, Error<Self::Error>>> + 'a
     where
         SPI: 'a;
     fn read_register<'a>(&'a mut self, register: u8) -> Self::ReadRegisterFuture<'a> {
@@ -184,7 +181,7 @@ where
         }
     }
 
-    type ReadDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>>>
+    type ReadDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>>> + 'a
     where
         SPI: 'a;
     fn read_data<'a>(&'a mut self, register: u8) -> Self::ReadDataFuture<'a> {
@@ -195,7 +192,7 @@ where
         }
     }
 
-    type ReadPtCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>>>
+    type ReadPtCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>>> + 'a
     where
         SPI: 'a;
     fn read_pt_calib_data<'a>(&'a mut self, register: u8) -> Self::ReadPtCalibDataFuture<'a> {
@@ -206,7 +203,7 @@ where
         }
     }
 
-    type ReadHCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>>>
+    type ReadHCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>>> + 'a
     where
         SPI: 'a;
     fn read_h_calib_data<'a>(&'a mut self, register: u8) -> Self::ReadHCalibDataFuture<'a> {
@@ -217,7 +214,7 @@ where
         }
     }
 
-    type WriteRegisterFuture<'a> = impl Future<Output = Result<(), Error<Self::Error>>>
+    type WriteRegisterFuture<'a> = impl Future<Output = Result<(), Error<Self::Error>>> + 'a
     where
         SPI: 'a;
     fn write_register<'a>(
@@ -248,7 +245,6 @@ where
 impl<SPI> AsyncSPIInterface<SPI>
 where
     SPI: AsyncSpiDevice,
-    SPI::Bus: AsyncSpiBus<u8>,
 {
     async fn read_any_register(
         &mut self,


### PR DESCRIPTION
Small patch to get it running with the latest version of embassy.

note: running cargo check will fail unless stm32f4xx-hal is removed or upgraded.