### PR TITLE
Fix cargo build and cargo build --examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ defmt-rtt = "0.3.0"
 panic-semihosting = "0.6"
 
 [dev-dependencies.stm32f4xx-hal]
-version = "0.13.2"
+version = "0.14"
 features = ["stm32f411"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bme280", "bmp280", "temperature", "pressure", "humidity"]
 categories = ["embedded", "no-std", "hardware-support", "embedded-hal"]
 edition = "2018"
+autoexamples = false
 
 [lib]
 name = "bme280"
@@ -15,16 +16,17 @@ name = "bme280"
 [dependencies]
 embedded-hal = "=1.0.0-alpha.8"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-defmt = { version = "0.3.2", optional = true }
+defmt = { version = "0.3", optional = true }
 derive_more = { version = "0.99.17", optional = true}
 embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
 maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]
 cortex-m-rtic = "1.0.0"
-cortex-m = "0.7.3"
+cortex-m = { version = "0.7.3", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
-defmt-rtt = "0.3.0"
+defmt = "0.3"
+defmt-rtt = "0.4"
 panic-semihosting = "0.6"
 
 [dev-dependencies.stm32f4xx-hal]

--- a/examples/rtic.rs
+++ b/examples/rtic.rs
@@ -1,6 +1,13 @@
+//! Example on using the BME 280 via i2c on a stm32f411.
+//!
+//! To run, make sure you install the correct rustup target:
+//! $ rustup target add thumbv7em-none-eabihf
+//! $ cargo build --target thumbv7em-none-eabihf --examples
+
 #![no_main]
 #![no_std]
 
+use defmt_rtt as _;
 use panic_semihosting as _;
 
 #[rtic::app(device = stm32f4xx_hal::pac)]
@@ -14,8 +21,8 @@ mod app {
         timer::delay::Delay,
     };
 
-    type Scl = Pin<Alternate<OpenDrain, 4>, 'B', 6>;
-    type Sda = Pin<Alternate<OpenDrain, 4>, 'B', 7>;
+    type Scl = Pin<'B', 6, Alternate<4, OpenDrain>>;
+    type Sda = Pin<'B', 7, Alternate<4, OpenDrain>>;
 
     #[shared]
     struct Shared {}


### PR DESCRIPTION
### Update stm32f4xx-hal to 0.14

stm32f4xx-hal 0.13.2 is pinned on embedded-hal =1.0.0-alpha.7, while bme280 is pinned on =1.0.0-alpha.8. Update the dependency so that `cargo build` succeeds.

### Fix build for examples/
Update Cargo.toml so that examples/rtic.rs can be build. The default build target is not updated, which means it is still possible to run `cargo build` successfully on x86_64 by default (without installing the thumbv7em toolchain target). I was not able to test this change as I do not have access to this device. Added some documentation to the example on how to run it.

Disable autoexamples in Cargo.toml as examples/basic.rs contains invalid syntax.

It is now possible to build the examples using:
$ cargo build --target thumbv7em-none-eabihf --examples