### PR TITLE
Use eHAL =1.0.0-rc.3 and fix async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ defmt-rtt = "0.3.0"
 panic-semihosting = "0.6"
 
 [dev-dependencies.stm32f4xx-hal]
-version = "0.13.2"
+version = "0.14.0"
 features = ["stm32f411"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 name = "bme280"
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.8"
+embedded-hal = "=1.0.0-rc.2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 defmt = { version = "0.3.2", optional = true }
 derive_more = { version = "0.99.17", optional = true}
-embedded-hal-async = { version = "0.1.0-alpha.1", optional = true }
+embedded-hal-async = { version = "=1.0.0-rc.2", optional = true }
 maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]
@@ -28,7 +28,7 @@ defmt-rtt = "0.3.0"
 panic-semihosting = "0.6"
 
 [dev-dependencies.stm32f4xx-hal]
-version = "0.14.0"
+version = "0.19.0"
 features = ["stm32f411"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 name = "bme280"
 
 [dependencies]
-embedded-hal = "=1.0.0-rc.2"
+embedded-hal = "=1.0.0-rc.3"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 defmt = { version = "0.3.2", optional = true }
 derive_more = { version = "0.99.17", optional = true}
-embedded-hal-async = { version = "=1.0.0-rc.2", optional = true }
+embedded-hal-async = { version = "=1.0.0-rc.3", optional = true }
 maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]
@@ -28,7 +28,8 @@ defmt-rtt = "0.3.0"
 panic-semihosting = "0.6"
 
 [dev-dependencies.stm32f4xx-hal]
-version = "0.19.0"
+git = "https://github.com/stm32-rs/stm32f4xx-hal" 
+rev = "f848188afb83f4f93af96d1fd3a4174ced5eb488"
 features = ["stm32f411"]
 
 [features]

--- a/examples/rtic.rs
+++ b/examples/rtic.rs
@@ -22,7 +22,7 @@ mod app {
 
     #[local]
     struct Local {
-        bme: BME280<I2c<I2C1, (Scl, Sda)>>,
+        bme: BME280<I2c<I2C1>>,
         delay: Delay<TIM2, 1000000>,
     }
 

--- a/examples/rtic.rs
+++ b/examples/rtic.rs
@@ -14,8 +14,8 @@ mod app {
         timer::delay::Delay,
     };
 
-    type Scl = Pin<Alternate<OpenDrain, 4>, 'B', 6>;
-    type Sda = Pin<Alternate<OpenDrain, 4>, 'B', 7>;
+    type Scl = Pin<'B', 6, Alternate<4, OpenDrain>>;
+    type Sda = Pin<'B', 7, Alternate<4, OpenDrain>>;
 
     #[shared]
     struct Shared {}

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -3,12 +3,12 @@
 #[cfg(feature = "async")]
 use core::future::Future;
 #[cfg(feature = "sync")]
-use embedded_hal::delay::blocking::DelayUs;
-#[cfg(feature = "sync")]
-use embedded_hal::i2c::blocking::I2c;
+use embedded_hal::delay::DelayNs;
 use embedded_hal::i2c::ErrorType;
+#[cfg(feature = "sync")]
+use embedded_hal::i2c::I2c;
 #[cfg(feature = "async")]
-use embedded_hal_async::delay::DelayUs as AsyncDelayUs;
+use embedded_hal_async::delay::DelayNs as AsyncDelayNs;
 #[cfg(feature = "async")]
 use embedded_hal_async::i2c::I2c as AsyncI2c;
 
@@ -44,7 +44,7 @@ pub struct AsyncBME280<I2C> {
         self = "BME280",
         idents(
             AsyncI2c(sync = "I2c"),
-            AsyncDelayUs(sync = "DelayUs"),
+            AsyncDelayNs(sync = "DelayNs"),
             AsyncBME280Common(sync = "BME280Common"),
         )
     ),
@@ -77,7 +77,7 @@ where
     /// Initializes the BME280.
     /// This configures 2x temperature oversampling, 16x pressure oversampling, and the IIR filter
     /// coefficient 16.
-    pub async fn init<D: AsyncDelayUs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
+    pub async fn init<D: AsyncDelayNs>(&mut self, delay: &mut D) -> Result<(), Error<I2C::Error>> {
         self.common
             .init(
                 delay,
@@ -91,7 +91,7 @@ where
     }
 
     /// Initializes the BME280, applying the given configuration.
-    pub async fn init_with_config<D: AsyncDelayUs>(
+    pub async fn init_with_config<D: AsyncDelayNs>(
         &mut self,
         delay: &mut D,
         config: Configuration,
@@ -100,7 +100,7 @@ where
     }
 
     /// Captures and processes sensor data for temperature, pressure, and humidity
-    pub async fn measure<D: AsyncDelayUs>(
+    pub async fn measure<D: AsyncDelayNs>(
         &mut self,
         delay: &mut D,
     ) -> Result<Measurements<I2C::Error>, Error<I2C::Error>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,9 @@
 #![cfg_attr(not(feature = "with_std"), no_std)]
 #![cfg_attr(
     feature = "async",
-    feature(generic_associated_types),
-    feature(type_alias_impl_trait),
-    feature(async_fn_in_trait)
+    feature(type_alias_impl_trait)
 )]
+#![feature(impl_trait_in_assoc_type)]
 
 //! A platform agnostic Rust driver for the Bosch BME280 and BMP280, based on the
 //! [`embedded-hal`](https://github.com/rust-embedded/embedded-hal) traits.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,9 @@
 #![cfg_attr(not(feature = "with_std"), no_std)]
 #![cfg_attr(
     feature = "async",
-    feature(type_alias_impl_trait)
+    feature(type_alias_impl_trait),
+    feature(impl_trait_in_assoc_type)
 )]
-#![feature(impl_trait_in_assoc_type)]
 
 //! A platform agnostic Rust driver for the Bosch BME280 and BMP280, based on the
 //! [`embedded-hal`](https://github.com/rust-embedded/embedded-hal) traits.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,9 @@ pub mod spi;
 use core::future::Future;
 use core::marker::PhantomData;
 #[cfg(feature = "sync")]
-use embedded_hal::delay::blocking::DelayUs;
+use embedded_hal::delay::DelayNs;
 #[cfg(feature = "async")]
-use embedded_hal_async::delay::DelayUs as AsyncDelayUs;
+use embedded_hal_async::delay::DelayNs as AsyncDelayNs;
 
 #[cfg(feature = "serde")]
 use serde::Serialize;
@@ -554,7 +554,7 @@ struct AsyncBME280Common<I> {
     sync(
         feature = "sync",
         self = "BME280Common",
-        idents(AsyncInterface(sync = "Interface"), AsyncDelayUs(sync = "DelayUs"),)
+        idents(AsyncInterface(sync = "Interface"), AsyncDelayNs(sync = "DelayNs"),)
     ),
     async(feature = "async", keep_self)
 )]
@@ -563,7 +563,7 @@ where
     I: AsyncInterface,
 {
     /// Initializes the BME280, applying the given config.
-    async fn init<D: AsyncDelayUs>(
+    async fn init<D: AsyncDelayNs>(
         &mut self,
         delay: &mut D,
         config: Configuration,
@@ -583,11 +583,11 @@ where
         }
     }
 
-    async fn soft_reset<D: AsyncDelayUs>(&mut self, delay: &mut D) -> Result<(), Error<I::Error>> {
+    async fn soft_reset<D: AsyncDelayNs>(&mut self, delay: &mut D) -> Result<(), Error<I::Error>> {
         self.interface
             .write_register(BME280_RESET_ADDR, BME280_SOFT_RESET_CMD)
             .await?;
-        delay.delay_ms(2).await.map_err(|_| Error::Delay)?; // startup time is 2ms
+        delay.delay_ms(2).await; // startup time is 2ms
         Ok(())
     }
 
@@ -604,7 +604,7 @@ where
         Ok(())
     }
 
-    async fn configure<D: AsyncDelayUs>(
+    async fn configure<D: AsyncDelayNs>(
         &mut self,
         delay: &mut D,
         config: Configuration,
@@ -662,11 +662,11 @@ where
         }
     }
 
-    async fn forced<D: AsyncDelayUs>(&mut self, delay: &mut D) -> Result<(), Error<I::Error>> {
+    async fn forced<D: AsyncDelayNs>(&mut self, delay: &mut D) -> Result<(), Error<I::Error>> {
         self.set_mode(BME280_FORCED_MODE, delay).await
     }
 
-    async fn set_mode<D: AsyncDelayUs>(
+    async fn set_mode<D: AsyncDelayNs>(
         &mut self,
         mode: u8,
         delay: &mut D,
@@ -683,12 +683,12 @@ where
     }
 
     /// Captures and processes sensor data for temperature, pressure, and humidity
-    async fn measure<D: AsyncDelayUs>(
+    async fn measure<D: AsyncDelayNs>(
         &mut self,
         delay: &mut D,
     ) -> Result<Measurements<I::Error>, Error<I::Error>> {
         self.forced(delay).await?;
-        delay.delay_ms(40).await.map_err(|_| Error::Delay)?; // await measurement
+        delay.delay_ms(40).await; // await measurement
         let measurements = self.interface.read_data(BME280_DATA_ADDR).await?;
         match self.calibration.as_mut() {
             Some(calibration) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@
 #![cfg_attr(
     feature = "async",
     feature(generic_associated_types),
-    feature(type_alias_impl_trait)
+    feature(type_alias_impl_trait),
+    feature(async_fn_in_trait)
 )]
 
 //! A platform agnostic Rust driver for the Bosch BME280 and BMP280, based on the

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -44,7 +44,6 @@ pub struct AsyncBME280<SPI> {
         self = "BME280",
         idents(
             AsyncSpiDevice(sync = "SpiDevice"),
-            AsyncSpiBus(sync = "SpiBus"),
             AsyncSPIInterface(sync = "SPIInterface"),
             AsyncDelayNs(sync = "DelayNs"),
             AsyncBME280Common(sync = "BME280Common"),
@@ -167,8 +166,7 @@ where
 #[cfg(feature = "async")]
 impl<SPI> AsyncInterface for AsyncSPIInterface<SPI>
 where
-    SPI: AsyncSpiDevice,
-    SPI::Bus: AsyncSpiBus<u8>,
+    SPI: AsyncSpiDevice
 {
     type Error = SPIError<SPI::Error>;
 
@@ -240,7 +238,7 @@ where
     sync(
         feature = "sync",
         self = "SPIInterface",
-        idents(AsyncSpiDevice(sync = "SpiDevice"), AsyncSpiBus(sync = "SpiBus"),)
+        idents(AsyncSpiDevice(sync = "SpiDevice"),)
     ),
     async(feature = "async", keep_self)
 )]

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -166,7 +166,7 @@ where
 #[cfg(feature = "async")]
 impl<SPI> AsyncInterface for AsyncSPIInterface<SPI>
 where
-    SPI: AsyncSpiDevice
+    SPI: AsyncSpiDevice,
 {
     type Error = SPIError<SPI::Error>;
 
@@ -252,9 +252,9 @@ where
         data: &mut [u8],
     ) -> Result<(), Error<SPIError<SPI::Error>>> {
         let register = [register];
-        let mut noperations = [Operation::Write(&register), Operation::Read(data)];
+        let mut operations = [Operation::Write(&register), Operation::Read(data)];
         self.spi
-            .transaction(&mut noperations)
+            .transaction(&mut operations)
             .await
             .map_err(|e| Error::Bus(SPIError::SPI(e)))?;
         Ok(())


### PR DESCRIPTION
This PR does the following:
- Upgrades `embedded-hal` and `embedded-hal-async` to `=1.0.0-rc.3`
- Fixes async build
- SPI: use `SpiDevice` exclusively 
- Incorporates #28 by applying its changes to the current HAL version (closes #28)