### PR TITLE
Fix soft_reset startup time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -581,7 +581,7 @@ where
         self.interface
             .write_register(BME280_RESET_ADDR, BME280_SOFT_RESET_CMD)
             .await?;
-        delay.delay_ns(2).await; // startup time is 2ms
+        delay.delay_ms(2).await; // startup time is 2ms
         Ok(())
     }
 


### PR DESCRIPTION
Changes `delay_ns` to `delay_ms` in `lib::AsyncBME280Common::soft_reset` to actually make the startup delay `2 ms` as stated in the comment. 2ns is definitely to short.