### PR TITLE
Fix SPI communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /example/target
 **/*.rs.bk
 Cargo.lock
+.idea


### PR DESCRIPTION
This fixes #25.
    
Any try to call the `init` function will fail with an `UnsupportedChip` error without this (using the default `sync` feature).
    
Previous attempts were made to fix this (#28 and #38) but these where made before `embedded-hal` `1.0.0` and currently have conflicts  preventing their merge (and can't directly be used in a project using `embedded-hal` `1.0.0`
    
closes #28
