### PR TITLE
Add fixed point compensation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,20 @@ derive_more = { version = "0.99.17", optional = true}
 embedded-hal-async = { version = "1.0.0", optional = true }
 maybe-async-cfg = "0.2.3"
 
+[dev-dependencies]
+linux-embedded-hal = { version = "0.4" }
+stm32f4xx-hal = { version = "0.22.1", features = ["stm32f407"] }
+panic-semihosting = "0.6.0"
+cortex-m-rtic = "1.1.4"
+
 [features]
 default = ["sync"]
 with_defmt = ["defmt"]
 with_std = ["derive_more"]
 sync = []
 async = ["embedded-hal-async"]
+cortexm = []
 
 [[example]]
 name = "rtic"
+required-features = ["cortexm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 defmt = { version = "0.3.5", optional = true }
 derive_more = { version = "0.99.17", optional = true}
 embedded-hal-async = { version = "1.0.0", optional = true }
+fixed = { version = "1.29", optional = true, default-features = false }
 maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/VersBinarii/bme280-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["bme280", "bmp280", "temperature", "pressure", "humidity"]
 categories = ["embedded", "no-std", "hardware-support", "embedded-hal"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "bme280"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ with_defmt = ["defmt"]
 with_std = ["derive_more"]
 sync = []
 async = ["embedded-hal-async"]
+serde = ["dep:serde", "fixed?/serde"]
 cortexm = []
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/VersBinarii/bme280-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["bme280", "bmp280", "temperature", "pressure", "humidity"]
 categories = ["embedded", "no-std", "hardware-support", "embedded-hal"]
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "bme280"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,15 +1,16 @@
 extern crate bme280;
-extern crate linux_embedded_hal as hal;
 
 use bme280::i2c::BME280;
-use hal::{Delay, I2cdev};
 use std::thread;
 use std::time::Duration;
 
+#[cfg(target_os = "linux")]
 fn main() {
+    use linux_embedded_hal::{Delay, I2cdev};
+
     let i2c_bus = I2cdev::new("/dev/i2c-1").unwrap();
     let mut bme280 = BME280::new_secondary(i2c_bus);
-    let delay = /*... some delay */
+    let mut delay = Delay;
     bme280.init(&mut delay).unwrap();
     loop {
         let measurements = bme280.measure(&mut delay).unwrap();
@@ -18,4 +19,10 @@ fn main() {
         println!("Pressure = {} pascals", measurements.pressure);
         thread::sleep(Duration::from_secs(1));
     }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    println!("This example is only for Linux with I2C support.");
+    println!("Please run it on a compatible device with the BME280 sensor connected via I2C.");
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -14,12 +14,12 @@ use embedded_hal_async::i2c::I2c as AsyncI2c;
 
 #[cfg(feature = "async")]
 use super::{AsyncBME280Common, AsyncInterface};
+use super::{
+    BME280_H_CALIB_DATA_LEN, BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN, Configuration,
+    Error, IIRFilter, Measurements, Oversampling,
+};
 #[cfg(feature = "sync")]
 use super::{BME280Common, Interface};
-use super::{
-    Configuration, Error, IIRFilter, Measurements, Oversampling, BME280_H_CALIB_DATA_LEN,
-    BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN,
-};
 
 const BME280_I2C_ADDR_PRIMARY: u8 = 0x76;
 const BME280_I2C_ADDR_SECONDARY: u8 = 0x77;

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -14,12 +14,16 @@ use embedded_hal_async::i2c::I2c as AsyncI2c;
 
 #[cfg(feature = "async")]
 use super::{AsyncBME280Common, AsyncInterface};
-use super::{
-    BME280_H_CALIB_DATA_LEN, BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN, Configuration,
-    Error, IIRFilter, Measurements, Oversampling,
-};
 #[cfg(feature = "sync")]
 use super::{BME280Common, Interface};
+
+use super::{
+    BME280_H_CALIB_DATA_LEN, BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN, Configuration,
+    Error, IIRFilter, Measurements, MeasurementsFixedRaw, Oversampling,
+};
+
+#[cfg(feature = "fixed")]
+use super::MeasurementsFixed;
 
 const BME280_I2C_ADDR_PRIMARY: u8 = 0x76;
 const BME280_I2C_ADDR_SECONDARY: u8 = 0x77;
@@ -105,6 +109,23 @@ where
         delay: &mut D,
     ) -> Result<Measurements<I2C::Error>, Error<I2C::Error>> {
         self.common.measure(delay).await
+    }
+
+    /// Captures and processes sensor data for temperature, pressure, and humidity in fixed point format
+    #[cfg(feature = "fixed")]
+    pub async fn measure_fixed<D: AsyncDelayNs>(
+        &mut self,
+        delay: &mut D,
+    ) -> Result<MeasurementsFixed<I2C::Error>, Error<I2C::Error>> {
+        self.common.measure_fixed(delay).await
+    }
+
+    /// Captures and processes sensor data for temperature, pressure, and humidity in raw fixed point format
+    pub async fn measure_fixed_raw<D: AsyncDelayNs>(
+        &mut self,
+        delay: &mut D,
+    ) -> Result<MeasurementsFixedRaw<I2C::Error>, Error<I2C::Error>> {
+        self.common.measure_fixed_raw(delay).await
     }
 }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -179,7 +179,8 @@ where
 {
     type Error = I2C::Error;
 
-    type ReadRegisterFuture<'a> = impl Future<Output = Result<u8, Error<Self::Error>>>
+    type ReadRegisterFuture<'a>
+        = impl Future<Output = Result<u8, Error<Self::Error>>>
     where
         I2C: 'a;
     fn read_register(&mut self, register: u8) -> Self::ReadRegisterFuture<'_> {
@@ -193,7 +194,8 @@ where
         }
     }
 
-    type ReadDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>>>
+    type ReadDataFuture<'a>
+        = impl Future<Output = Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>>>
     where
         I2C: 'a;
     fn read_data(&mut self, register: u8) -> Self::ReadDataFuture<'_> {
@@ -207,7 +209,8 @@ where
         }
     }
 
-    type ReadPtCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>>>
+    type ReadPtCalibDataFuture<'a>
+        = impl Future<Output = Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>>>
     where
         I2C: 'a;
     fn read_pt_calib_data(&mut self, register: u8) -> Self::ReadPtCalibDataFuture<'_> {
@@ -221,7 +224,8 @@ where
         }
     }
 
-    type ReadHCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>>>
+    type ReadHCalibDataFuture<'a>
+        = impl Future<Output = Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>>>
     where
         I2C: 'a;
     fn read_h_calib_data(&mut self, register: u8) -> Self::ReadHCalibDataFuture<'_> {
@@ -235,7 +239,8 @@ where
         }
     }
 
-    type WriteRegisterFuture<'a> = impl Future<Output = Result<(), Error<Self::Error>>>
+    type WriteRegisterFuture<'a>
+        = impl Future<Output = Result<(), Error<Self::Error>>>
     where
         I2C: 'a;
     fn write_register(&mut self, register: u8, payload: u8) -> Self::WriteRegisterFuture<'_> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ use embedded_hal_async::delay::DelayNs as AsyncDelayNs;
 use serde::Serialize;
 
 #[cfg(feature = "with_defmt")]
-use defmt::{write, Format, Formatter};
+use defmt::{Format, Formatter, write};
 
 #[cfg(feature = "with_std")]
 use derive_more::Display;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,7 @@ pub struct MeasurementsFixedRaw<E> {
 
 /// Fixed-point measurement data in fixed point format
 #[cfg(feature = "fixed")]
-//#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug)]
 pub struct MeasurementsFixed<E> {
     /// temperature in hundreths of degrees celsius 2134 for 21.34 deg C
@@ -405,7 +405,7 @@ pub struct MeasurementsFixed<E> {
     pub pressure: ::fixed::types::U24F8,
     /// percent relative humidity in Q22.10 format (`0` with BMP280)
     pub humidity: ::fixed::types::U22F10,
-    //#[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     _e: PhantomData<E>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,13 +413,7 @@ impl<E> Measurements<E> {
         calibration.t_fine = (var1 + var2) as i32;
 
         let temperature = (var1 + var2) / 5120.0;
-        let temperature = if temperature < BME280_TEMP_MIN {
-            BME280_TEMP_MIN
-        } else if temperature > BME280_TEMP_MAX {
-            BME280_TEMP_MAX
-        } else {
-            temperature
-        };
+        let temperature = temperature.clamp(BME280_TEMP_MIN, BME280_TEMP_MAX);
         Ok(temperature)
     }
 
@@ -441,13 +435,7 @@ impl<E> Measurements<E> {
             let var1 = calibration.dig_p9 as f32 * pressure * pressure / 2147483648.0;
             let var2 = pressure * calibration.dig_p8 as f32 / 32768.0;
             let pressure = pressure + (var1 + var2 + calibration.dig_p7 as f32) / 16.0;
-            if pressure < BME280_PRESSURE_MIN {
-                BME280_PRESSURE_MIN
-            } else if pressure > BME280_PRESSURE_MAX {
-                BME280_PRESSURE_MAX
-            } else {
-                pressure
-            }
+            pressure.clamp(BME280_PRESSURE_MIN, BME280_PRESSURE_MAX)
         } else {
             return Err(Error::InvalidData);
         };
@@ -467,13 +455,7 @@ impl<E> Measurements<E> {
         let var6 = var3 * var4 * (var5 * var6);
 
         let humidity = var6 * (1.0 - calibration.dig_h1 as f32 * var6 / 524288.0);
-        let humidity = if humidity < BME280_HUMIDITY_MIN {
-            BME280_HUMIDITY_MIN
-        } else if humidity > BME280_HUMIDITY_MAX {
-            BME280_HUMIDITY_MAX
-        } else {
-            humidity
-        };
+        let humidity = humidity.clamp(BME280_HUMIDITY_MIN, BME280_HUMIDITY_MAX);
         Ok(humidity)
     }
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -14,12 +14,16 @@ use embedded_hal_async::spi::SpiDevice as AsyncSpiDevice;
 
 #[cfg(feature = "async")]
 use super::{AsyncBME280Common, AsyncInterface};
-use super::{
-    BME280_H_CALIB_DATA_LEN, BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN, Configuration,
-    Error, IIRFilter, Measurements, Oversampling,
-};
 #[cfg(feature = "sync")]
 use super::{BME280Common, Interface};
+
+use super::{
+    BME280_H_CALIB_DATA_LEN, BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN, Configuration,
+    Error, IIRFilter, Measurements, MeasurementsFixedRaw, Oversampling,
+};
+
+#[cfg(feature = "fixed")]
+use super::MeasurementsFixed;
 
 /// Representation of a BME280
 #[maybe_async_cfg::maybe(
@@ -101,6 +105,23 @@ where
         delay: &mut D,
     ) -> Result<Measurements<SPIError<SPIE>>, Error<SPIError<SPIE>>> {
         self.common.measure(delay).await
+    }
+
+    /// Captures and processes sensor data for temperature, pressure, and humidity in fixed point format
+    #[cfg(feature = "fixed")]
+    pub async fn measure_fixed<D: AsyncDelayNs>(
+        &mut self,
+        delay: &mut D,
+    ) -> Result<MeasurementsFixed<SPIError<SPIE>>, Error<SPIError<SPIE>>> {
+        self.common.measure_fixed(delay).await
+    }
+
+    /// Captures and processes sensor data for temperature, pressure, and humidity in raw fixed point format
+    pub async fn measure_fixed_raw<D: AsyncDelayNs>(
+        &mut self,
+        delay: &mut D,
+    ) -> Result<MeasurementsFixedRaw<SPIError<SPIE>>, Error<SPIError<SPIE>>> {
+        self.common.measure_fixed_raw(delay).await
     }
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -14,12 +14,12 @@ use embedded_hal_async::spi::SpiDevice as AsyncSpiDevice;
 
 #[cfg(feature = "async")]
 use super::{AsyncBME280Common, AsyncInterface};
+use super::{
+    BME280_H_CALIB_DATA_LEN, BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN, Configuration,
+    Error, IIRFilter, Measurements, Oversampling,
+};
 #[cfg(feature = "sync")]
 use super::{BME280Common, Interface};
-use super::{
-    Configuration, Error, IIRFilter, Measurements, Oversampling, BME280_H_CALIB_DATA_LEN,
-    BME280_P_T_CALIB_DATA_LEN, BME280_P_T_H_DATA_LEN,
-};
 
 /// Representation of a BME280
 #[maybe_async_cfg::maybe(

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -174,7 +174,8 @@ where
 {
     type Error = SPIError<SPI::Error>;
 
-    type ReadRegisterFuture<'a> = impl Future<Output = Result<u8, Error<Self::Error>>>
+    type ReadRegisterFuture<'a>
+        = impl Future<Output = Result<u8, Error<Self::Error>>>
     where
         SPI: 'a;
     fn read_register(&mut self, register: u8) -> Self::ReadRegisterFuture<'_> {
@@ -185,7 +186,8 @@ where
         }
     }
 
-    type ReadDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>>>
+    type ReadDataFuture<'a>
+        = impl Future<Output = Result<[u8; BME280_P_T_H_DATA_LEN], Error<Self::Error>>>
     where
         SPI: 'a;
     fn read_data(&mut self, register: u8) -> Self::ReadDataFuture<'_> {
@@ -196,7 +198,8 @@ where
         }
     }
 
-    type ReadPtCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>>>
+    type ReadPtCalibDataFuture<'a>
+        = impl Future<Output = Result<[u8; BME280_P_T_CALIB_DATA_LEN], Error<Self::Error>>>
     where
         SPI: 'a;
     fn read_pt_calib_data(&mut self, register: u8) -> Self::ReadPtCalibDataFuture<'_> {
@@ -207,7 +210,8 @@ where
         }
     }
 
-    type ReadHCalibDataFuture<'a> = impl Future<Output = Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>>>
+    type ReadHCalibDataFuture<'a>
+        = impl Future<Output = Result<[u8; BME280_H_CALIB_DATA_LEN], Error<Self::Error>>>
     where
         SPI: 'a;
     fn read_h_calib_data(&mut self, register: u8) -> Self::ReadHCalibDataFuture<'_> {
@@ -218,7 +222,8 @@ where
         }
     }
 
-    type WriteRegisterFuture<'a> = impl Future<Output = Result<(), Error<Self::Error>>>
+    type WriteRegisterFuture<'a>
+        = impl Future<Output = Result<(), Error<Self::Error>>>
     where
         SPI: 'a;
     fn write_register(&mut self, register: u8, payload: u8) -> Self::WriteRegisterFuture<'_> {
@@ -252,11 +257,8 @@ where
         register: u8,
         data: &mut [u8],
     ) -> Result<(), Error<SPIError<SPI::Error>>> {
-       self.spi
-            .transaction(&mut [
-                Operation::Write(&[register]),
-                Operation::Read(data)
-            ])
+        self.spi
+            .transaction(&mut [Operation::Write(&[register]), Operation::Read(data)])
             .await
             .map_err(|e| Error::Bus(SPIError::SPI(e)))?;
         Ok(())


### PR DESCRIPTION
Returns raw i32 / u32 or, with the "fixed" feature enabled, proper fixed point numbers from the "fixed" crate.

Builds upon the previous "maintenance" PR https://github.com/VersBinarii/bme280-rs/pull/44